### PR TITLE
Fix login and register pages

### DIFF
--- a/app/src/main/java/com/example/cupetfrontend/ui/login/LoginViewModel.java
+++ b/app/src/main/java/com/example/cupetfrontend/ui/login/LoginViewModel.java
@@ -62,6 +62,10 @@ public class LoginViewModel extends ViewModel implements ILoginViewModel {
         LoginResult newLoginResult = new LoginResult(false);
         newLoginResult.setToken(token);
 
+        // TODO: Remove after demo
+        System.out.println("Login success with token: " + token);
+        System.out.println("Login success with user id: " + token);
+
         loginResult.setValue(newLoginResult);
     }
 

--- a/app/src/main/java/com/example/cupetfrontend/use_cases/LoginUseCase.java
+++ b/app/src/main/java/com/example/cupetfrontend/use_cases/LoginUseCase.java
@@ -28,7 +28,23 @@ public class LoginUseCase implements LoginInputBoundary {
         authAPIGateway.login(apiRequest, new IServerResponseListener() {
             @Override
             public void onRequestSuccess(JSONObject jsonResponse) {
-                outputBoundary.onLoginSuccess(toSuccessResponseModel(jsonResponse));
+                // TODO: Remove temporary code
+                //  The API currently does not support HTTP status codes, so we need this
+                //  code to prevent a runtime exception from crashing the application
+
+                try {
+                    if (jsonResponse.get("isSuccess").equals("true")){
+                        outputBoundary.onLoginSuccess(toSuccessResponseModel(jsonResponse));
+                    }else{
+                        outputBoundary.onLoginFailure(toFailResponseModel(jsonResponse));
+                    }
+                } catch (JSONException e) {
+                    throw new InvalidAPIResponseException(
+                            "The API gave an invalid login response:" + jsonResponse);
+                }
+
+                // TODO: Uncomment when API is updated.
+//                outputBoundary.onLoginSuccess(toSuccessResponseModel(jsonResponse));
             }
 
             @Override

--- a/app/src/main/java/com/example/cupetfrontend/use_cases/UserCreator.java
+++ b/app/src/main/java/com/example/cupetfrontend/use_cases/UserCreator.java
@@ -29,7 +29,23 @@ public class UserCreator implements UserCreatorInputBoundary {
         userAPIGateway.createUser(apiRequest, new IServerResponseListener() {
             @Override
             public void onRequestSuccess(JSONObject jsonResponse) {
-                outputBoundary.onCreateUserSuccess(toSuccessResponseModel(jsonResponse));
+                // TODO: Remove temporary code
+                //  The API currently does not support HTTP status codes, so we need this
+                //  code to prevent a runtime exception from crashing the application
+
+                try {
+                    if (jsonResponse.get("isSuccess").equals("true")){
+                        outputBoundary.onCreateUserSuccess(toSuccessResponseModel(jsonResponse));
+                    }else{
+                        outputBoundary.onCreateUserFailure(toFailResponseModel(jsonResponse));
+                    }
+                } catch (JSONException e) {
+                    throw new InvalidAPIResponseException(
+                            "The API gave an invalid create user response:" + jsonResponse);
+                }
+
+                // TODO: Uncomment when API is updated.
+//                outputBoundary.onCreateUserSuccess(toSuccessResponseModel(jsonResponse));
             }
 
             @Override
@@ -60,7 +76,8 @@ public class UserCreator implements UserCreatorInputBoundary {
                     dataObj.getString("userId")
             );
         } catch (JSONException e) {
-            throw new InvalidAPIResponseException("The API gave an invalid successful create user response.");
+            throw new InvalidAPIResponseException(
+                    "The API gave an invalid successful create user response: " + jsonResponse);
         }
     }
 
@@ -75,7 +92,8 @@ public class UserCreator implements UserCreatorInputBoundary {
         try {
             return new UserCreatorFailResponseModel(jsonResponse.getString("message"));
         } catch (JSONException e) {
-            throw new InvalidAPIResponseException("The API gave an invalid failed create user response.");
+            throw new InvalidAPIResponseException(
+                    "The API gave an invalid failed create user response: " + jsonResponse);
         }
     }
 }


### PR DESCRIPTION
This PR fixes some minor bugs with the registration and login pages:

* Fix a crash that occurs given incorrect credentials. Technically, the code for this is already fine as is and it's the backend which needs to be updated. This PR provides a hotfix that addresses the error on the backend for the time-being in preparation for the Phase 1 demo.
* Fix a small bug where the home address field would get a field error even if the entered data passes validation.